### PR TITLE
BLOG-128: Cannot use HTML5 in Blog Posts

### DIFF
--- a/application-blog-ui/src/main/resources/Blog/BlogCode.xml
+++ b/application-blog-ui/src/main/resources/Blog/BlogCode.xml
@@ -753,7 +753,7 @@ $!xwiki.jsx.use($blogScriptsDocumentName)##
   #getEntryContent($entryDoc $entryObj $onlyExtract $entryContent)
   ## FIXME: This causes the blog's content to not be annotatable. See http://jira.xwiki.org/browse/XWIKI-6328
   ##        Should probably be replaced by a display macro call with a reference to the object property holding the post's content
-  {{html wiki="false"}}$entryDoc.getRenderedContent($entryContent, $entryDoc.syntax.toIdString()){{/html}}
+  {{html clean="false" wiki="false"}}$entryDoc.getRenderedContent($entryContent, $entryDoc.syntax.toIdString()){{/html}}
   ))) ## entry-content
   (% class="clearfloats" %)((()))
 #end


### PR DESCRIPTION
Issues described at https://jira.xwiki.org/browse/BLOG-128

Fix suggested by @mflorea . Thank you

After: 
<img width="400" alt="expected" src="https://user-images.githubusercontent.com/629552/51261407-d8979380-19b8-11e9-95a0-ad2b91ffd57a.png">
