### PR TITLE
BLOG-102: The placeholder text from 'Create a new post' box does not disappear when start typing on Edge

### DIFF
--- a/application-blog-ui/src/main/resources/Blog/CreatePost.xml
+++ b/application-blog-ui/src/main/resources/Blog/CreatePost.xml
@@ -68,7 +68,9 @@
     #if($doc.getObject($blogCategoryClassname))
       &lt;input type="hidden" name="category" value="$services.rendering.escape(${escapetool.xml(${doc.fullName})}, $doc.syntax)"/&gt;
     #end
-    $services.icon.renderHTML('add')&lt;label class="createPost" for="entryTitle"&gt;$services.localization.render('blog.post.createpost') &lt;/label&gt;&lt;input type="text" id="entryTitle" name="entryTitle" value="$services.localization.render('blog.post.title')" class="withTip" size="30" /&gt; &lt;span class="buttonwrapper"&gt;&lt;input type="submit" value="${escapetool.xml($services.localization.render('blog.post.create'))}" class="btn btn-success button"/&gt;&lt;/span&gt;
+    $services.icon.renderHTML('add')&lt;label class="createPost" for="entryTitle"&gt;$services.localization.render('blog.post.createpost') &lt;/label&gt;
+    &lt;input type="text" id="entryTitle" name="entryTitle" size="30" placeholder="$services.localization.render('blog.post.title')"/&gt; &lt;span class="buttonwrapper"&gt;
+    &lt;input type="submit" value="${escapetool.xml($services.localization.render('blog.post.create'))}" class="btn btn-success button"/&gt;&lt;/span&gt;
   &lt;/div&gt;
   &lt;/form&gt;
   #elseif("$!request.entryTitle" != '')## !hasEdit &amp;&amp; form submitted


### PR DESCRIPTION
Has the same effect as [PR #1118](https://github.com/xwiki/xwiki-platform/pull/1118). [`withTip`](https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/FrontendResources/SpecialCSSClasses/#HB2.Behaviorclassnames) class was a solving for unavailability (in that version) of HTML5. Adding a placeholder (as the [solution](https://jira.xwiki.org/browse/XWIKI-14819?focusedCommentId=96747&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-96747) proposed by @mflorea) has the same effect and it's a possible fix. 
