### PR TITLE
BLOG-163: BlogPostList macro cannot display the list of all blog posts of a wiki if a global blog does not exist

### DIFF
--- a/application-blog-ui/src/main/resources/Blog/BlogPostList.xml
+++ b/application-blog-ui/src/main/resources/Blog/BlogPostList.xml
@@ -165,12 +165,7 @@
 {{include reference='Blog.BlogPostLayoutMacros' /}}
 
 {{velocity output='no'}}
-#if ("$!xcontext.macro.params.blog" == '' &amp;&amp; "$!xcontext.macro.params.category" == '')
-  #set ($blogDescriptorParam = 'Blog.WebHome') ## Default Blog descriptor
-#else
-  #set ($blogDescriptorParam = $xcontext.macro.params.blog)
-#end
-
+#set ($blogDescriptorParam = $xcontext.macro.params.blog)
 #set ($categoryParam = $xcontext.macro.params.category)
 #set ($fromDateParam = $xcontext.macro.params.fromDate)
 #set ($toDateParam = $xcontext.macro.params.toDate)


### PR DESCRIPTION
* Removed the assumption that when no blog is referred the "default blog" Blog.WebHome should be used 

I checked the risks of this strategy for the default usage of blogpostlist, and there is not much, all the usages of the blogpostlist macro in the blog application explicitly specify a blog to list posts from.
Thus, this change would only impact users of the blogpostlist macro that have been using the macro without parameters in order to point to a Blog.WebHome blog that is not global.
As mentioned in the issue comments, there may also be some consequences on the blog posts without category, which may now get listed when using the blogpostlist macro without parameters, while they were not getting listed before.
Also, there is an impact on the layout parameters, they're not copied anymore from the Blog.WebHome when using the blogpostlist macro without parameters, they used to be.