### PR TITLE
Remove usage of deprecated methods

### DIFF
--- a/application-blog-ui/src/main/resources/Blog/BlogCode.xml
+++ b/application-blog-ui/src/main/resources/Blog/BlogCode.xml
@@ -894,19 +894,19 @@ $!xwiki.jsx.use($blogScriptsDocumentName)##
     (% class="pagingLinks" %)(((
     #getRequestedWeek($weekDate)
     $weekDate.addWeeks(-1)##
-    (% class="prevPage" %)**[[« {{translation key='blog.code.previousweek'/}}&gt;&gt;$doc.name||queryString="year=$weekDate.weekyear&amp;week=$weekDate.weekOfWeekyear" class="button"]]**(%%)
+    (% class="prevPage" %)**[[« {{translation key='blog.code.previousweek'/}}&gt;&gt;$doc.documentReference.name||queryString="year=$weekDate.weekyear&amp;week=$weekDate.weekOfWeekyear" class="button"]]**(%%)
     #sep()
     $weekDate.addWeeks(2)## 2 because we already subtracted 1 above
-    (% class="nextPage" %)**[[{{translation key='blog.code.nextweek'/}} »&gt;&gt;$doc.name||queryString="year=$weekDate.weekyear&amp;week=$weekDate.weekOfWeekyear" class="button"]]**(%%)
+    (% class="nextPage" %)**[[{{translation key='blog.code.nextweek'/}} »&gt;&gt;$doc.documentReference.name||queryString="year=$weekDate.weekyear&amp;week=$weekDate.weekOfWeekyear" class="button"]]**(%%)
     )))
   #elseif($displayType == 'monthly')
     (% class="pagingLinks" %)(((
     #getRequestedMonth($monthDate)
     $monthDate.addMonths(-1)##
-    (% class="prevPage" %)**[[« {{translation key='blog.code.previousmonth'/}}&gt;&gt;$services.rendering.escape($doc.name,$doc.syntax)||queryString="year=$monthDate.year&amp;month=$monthDate.monthOfYear" class="button"]]**(%%)
+    (% class="prevPage" %)**[[« {{translation key='blog.code.previousmonth'/}}&gt;&gt;$services.rendering.escape($doc.documentReference.name,$doc.syntax)||queryString="year=$monthDate.year&amp;month=$monthDate.monthOfYear" class="button"]]**(%%)
     #sep()
     $monthDate.addMonths(2)## 2 because we already subtracted 1 above
-    (% class="nextPage" %)**[[{{translation key='blog.code.nextmonth'/}} »&gt;&gt;$services.rendering.escape($doc.name,$doc.syntax)||queryString="year=$monthDate.year&amp;month=$monthDate.monthOfYear" class="button"]]**(%%)
+    (% class="nextPage" %)**[[{{translation key='blog.code.nextmonth'/}} »&gt;&gt;$services.rendering.escape($doc.documentReference.name,$doc.syntax)||queryString="year=$monthDate.year&amp;month=$monthDate.monthOfYear" class="button"]]**(%%)
     )))
   #elseif($displayType == 'all')
   #else
@@ -923,7 +923,7 @@ $!xwiki.jsx.use($blogScriptsDocumentName)##
       (% class="pagingLinks" %)(((
       #if ($currentPageNumber &lt; $totalPages)
         #set($currentPageNumber = $currentPageNumber + 1)
-        (% class="prevPage" %)**[[« {{translation key='blog.code.olderposts'/}}&gt;&gt;$services.rendering.escape($doc.name,$doc.syntax)||queryString="page=${currentPageNumber}&amp;ipp=${itemsPerPage}$queryString" class="button"]]**(%%)
+        (% class="prevPage" %)**[[« {{translation key='blog.code.olderposts'/}}&gt;&gt;$services.rendering.escape($doc.documentReference.name,$doc.syntax)||queryString="page=${currentPageNumber}&amp;ipp=${itemsPerPage}$queryString" class="button"]]**(%%)
         #set($currentPageNumber = $currentPageNumber - 1)
       #end
       #if ($currentPageNumber &gt; 1)
@@ -931,7 +931,7 @@ $!xwiki.jsx.use($blogScriptsDocumentName)##
           #sep()
         #end
         #set($currentPageNumber = $currentPageNumber - 1)
-        (% class="nextPage" %)**[[{{translation key='blog.code.newerposts'/}} »&gt;&gt;$services.rendering.escape($doc.name,$doc.syntax)||queryString="page=${currentPageNumber}&amp;ipp=${itemsPerPage}$queryString" class="button"]]**(%%)
+        (% class="nextPage" %)**[[{{translation key='blog.code.newerposts'/}} »&gt;&gt;$services.rendering.escape($doc.documentReference.name,$doc.syntax)||queryString="page=${currentPageNumber}&amp;ipp=${itemsPerPage}$queryString" class="button"]]**(%%)
         #set($currentPageNumber = $currentPageNumber + 1)
       #end
       (% class="clear" %)(%%)

--- a/application-blog-ui/src/main/resources/Blog/RssCode.xml
+++ b/application-blog-ui/src/main/resources/Blog/RssCode.xml
@@ -163,7 +163,7 @@
       ## This is just a list of blog entries, which are detailed below.
       #foreach ($entryDoc in $entries)
         #if($xwiki.hasAccessLevel('view', ${entryDoc.fullName}))
-        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLocale.language}")" /&gt;
+        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLocale}")" /&gt;
         #end
       #end
       &lt;/rdf:Seq&gt;
@@ -194,7 +194,7 @@
       ## This is just a list of blog entries, which are detailed below.
       #foreach ($entryDoc in $entries)
         #if($xwiki.hasAccessLevel('view', ${entryDoc.fullName}))
-        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLocal.language}")" /&gt;
+        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLocale}")" /&gt;
         #end
       #end
       &lt;/rdf:Seq&gt;
@@ -229,7 +229,7 @@
       ## This is just a list of blog entries, which are detailed below.
       #foreach ($entryDoc in $entries)
         #if($xwiki.hasAccessLevel('view', ${entryDoc.fullName}))
-        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLocale.language}")" /&gt;
+        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLocale}")" /&gt;
         #end
       #end
       &lt;/rdf:Seq&gt;
@@ -279,7 +279,7 @@
  * @param entryDoc The XDocument corresponding to the displayed blog entry.
  *###
 #macro(printBlogRssItem $entryDoc)
-  #set($entryUrl = $entryDoc.getExternalURL('view', "language=${entryDoc.realLocale.language}"))
+  #set($entryUrl = $entryDoc.getExternalURL('view', "language=${entryDoc.realLocale}"))
   #getEntryObject($entryDoc $entryObj)
   #getEntryContent($entryDoc $entryObj true $entryContent)
   #if($!entryDoc.syntax.toIdString() == 'xwiki/1.0')

--- a/application-blog-ui/src/main/resources/Blog/RssCode.xml
+++ b/application-blog-ui/src/main/resources/Blog/RssCode.xml
@@ -163,7 +163,7 @@
       ## This is just a list of blog entries, which are detailed below.
       #foreach ($entryDoc in $entries)
         #if($xwiki.hasAccessLevel('view', ${entryDoc.fullName}))
-        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLanguage}")" /&gt;
+        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLocale.language}")" /&gt;
         #end
       #end
       &lt;/rdf:Seq&gt;
@@ -194,7 +194,7 @@
       ## This is just a list of blog entries, which are detailed below.
       #foreach ($entryDoc in $entries)
         #if($xwiki.hasAccessLevel('view', ${entryDoc.fullName}))
-        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLanguage}")" /&gt;
+        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLocal.language}")" /&gt;
         #end
       #end
       &lt;/rdf:Seq&gt;
@@ -229,7 +229,7 @@
       ## This is just a list of blog entries, which are detailed below.
       #foreach ($entryDoc in $entries)
         #if($xwiki.hasAccessLevel('view', ${entryDoc.fullName}))
-        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLanguage}")" /&gt;
+        &lt;rdf:li rdf:resource="$entryDoc.getExternalURL('view', "language=${entryDoc.realLocale.language}")" /&gt;
         #end
       #end
       &lt;/rdf:Seq&gt;
@@ -279,7 +279,7 @@
  * @param entryDoc The XDocument corresponding to the displayed blog entry.
  *###
 #macro(printBlogRssItem $entryDoc)
-  #set($entryUrl = $entryDoc.getExternalURL('view', "language=${entryDoc.realLanguage}"))
+  #set($entryUrl = $entryDoc.getExternalURL('view', "language=${entryDoc.realLocale.language}"))
   #getEntryObject($entryDoc $entryObj)
   #getEntryContent($entryDoc $entryObj true $entryContent)
   #if($!entryDoc.syntax.toIdString() == 'xwiki/1.0')


### PR DESCRIPTION
- Replace usage of `$doc.name` with `$doc.pageReference.name`.
- Replace usage of `$doc.realLanguage` with `$doc.realLocale.language`.

This should close https://jira.xwiki.org/browse/BLOG-137 and https://jira.xwiki.org/browse/BLOG-155.