### PR TITLE
BLOG-228: Month names of BlogArchive are displayed using JVM locale instead of XWiki context locale

### DIFF
--- a/application-blog-ui/src/main/resources/Blog/ArchiveSheet.xml
+++ b/application-blog-ui/src/main/resources/Blog/ArchiveSheet.xml
@@ -50,7 +50,8 @@
   #set ($discard = $queryParams.put('creator', $xcontext.user))
   #set ($query = "$!{query} and (doc.creator = :creator or (isPublished.value = 1 and hidden.value = 0))")
   ## Create a Jodatime date formatter that will be used to format dates
-  #set($monthFormatter = $xwiki.jodatime.getDateTimeFormatterForPattern('MMMM'))
+  #set($currentLocale = $xcontext.locale)
+  #set($monthFormatter = $xwiki.jodatime.getDateTimeFormatterForPattern('MMMM').withLocale($currentLocale))
   #set($tempDate = $xwiki.jodatime.mutableDateTime)
   #set($currentYear = $xwiki.formatDate($datetool.date, 'yyyy'))
   #set($currentMonth = $xwiki.formatDate($datetool.date, 'M'))

--- a/application-blog-ui/src/main/resources/Blog/ArchiveSheet.xml
+++ b/application-blog-ui/src/main/resources/Blog/ArchiveSheet.xml
@@ -50,8 +50,7 @@
   #set ($discard = $queryParams.put('creator', $xcontext.user))
   #set ($query = "$!{query} and (doc.creator = :creator or (isPublished.value = 1 and hidden.value = 0))")
   ## Create a Jodatime date formatter that will be used to format dates
-  #set($currentLocale = $xcontext.locale)
-  #set($monthFormatter = $xwiki.jodatime.getDateTimeFormatterForPattern('MMMM').withLocale($currentLocale))
+  #set($monthFormatter = $xwiki.jodatime.getDateTimeFormatterForPattern('MMMM').withLocale($xcontext.locale))
   #set($tempDate = $xwiki.jodatime.mutableDateTime)
   #set($currentYear = $xwiki.formatDate($datetool.date, 'yyyy'))
   #set($currentMonth = $xwiki.formatDate($datetool.date, 'M'))
@@ -109,7 +108,7 @@
   #set($query = "${query} and year(publishDate.value) = :year")
   #set ($discard = $queryParams.put('year', $numbertool.toNumber($year).intValue()))
   ## Create a Jodatime date formatter that will be used to format dates
-  #set($monthFormatter = $xwiki.jodatime.getDateTimeFormatterForPattern('MMMM'))
+  #set($monthFormatter = $xwiki.jodatime.getDateTimeFormatterForPattern('MMMM').withLocale($xcontext.locale))
   #set($tempDate = $xwiki.jodatime.mutableDateTime)
   #set ($yearArticleCountQueryObj = $services.query.hql($query).addFilter('unique'))
   #bindQueryParameters($yearArticleCountQueryObj $queryParams)


### PR DESCRIPTION
Jira issue [BLOG-228](https://jira.xwiki.org/browse/BLOG-228)

Before the fix

![image](https://github.com/user-attachments/assets/d2afa133-d2ea-4b88-8c65-f5aca4d83eb0)


After the fix with French locale

![image](https://github.com/user-attachments/assets/6067cec6-a3dd-48d0-aac3-58e0c6462c9d)
